### PR TITLE
#1: tagCloudItemClickable modifier

### DIFF
--- a/demo/src/main/java/eu/wewox/tagcloud/screens/SimpleTagCloudScreen.kt
+++ b/demo/src/main/java/eu/wewox/tagcloud/screens/SimpleTagCloudScreen.kt
@@ -1,5 +1,6 @@
 package eu.wewox.tagcloud.screens
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -11,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import eu.wewox.tagcloud.Example
 import eu.wewox.tagcloud.TagCloud
@@ -40,6 +42,7 @@ fun SimpleTagCloudScreen() {
 @Composable
 private fun SimpleTagCloud() {
     val labels = List(32) { "Item #$it" }
+    val ctx = LocalContext.current
 
     TagCloud(
         state = rememberTagCloudState(),
@@ -52,6 +55,9 @@ private fun SimpleTagCloud() {
                 modifier = Modifier
                     .tagCloudItemFade()
                     .tagCloudItemScaleDown()
+                    .tagCloudItemClickable {
+                        Toast.makeText(ctx, "Clicked", Toast.LENGTH_SHORT).show()
+                    }
             ) {
                 Text(
                     text = it,

--- a/tagcloud/src/main/java/eu/wewox/tagcloud/TagCloudItemScope.kt
+++ b/tagcloud/src/main/java/eu/wewox/tagcloud/TagCloudItemScope.kt
@@ -1,7 +1,17 @@
 package eu.wewox.tagcloud
 
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.semantics.Role
 import eu.wewox.tagcloud.math.Vector3
 
 /**
@@ -28,6 +38,22 @@ public interface TagCloudItemScope {
      * @param toScale The scale for most items (with lowest z coordinate).
      */
     public fun Modifier.tagCloudItemScaleDown(toScale: Float = 0.5f): Modifier
+
+    public fun Modifier.tagCloudItemClickable(
+        interactionSource: MutableInteractionSource,
+        indication: Indication?,
+        enabled: Boolean = true,
+        onClickLabel: String? = null,
+        role: Role? = null,
+        onClick: () -> Unit
+    ): Modifier
+
+    public fun Modifier.tagCloudItemClickable(
+        enabled: Boolean = true,
+        onClickLabel: String? = null,
+        role: Role? = null,
+        onClick: () -> Unit
+    ): Modifier
 }
 
 /**
@@ -48,6 +74,63 @@ internal class TagCloudItemScopeImpl(
             scaleX = scale
             scaleY = scale
         }
+
+    override fun Modifier.tagCloudItemClickable(
+        interactionSource: MutableInteractionSource,
+        indication: Indication?,
+        enabled: Boolean,
+        onClickLabel: String?,
+        role: Role?,
+        onClick: () -> Unit
+    ): Modifier = tagCloudItemPointerInputClickable(enabled) { onClick() }
+        .clickable(interactionSource, indication, enabled, onClickLabel, role) {}
+
+    override fun Modifier.tagCloudItemClickable(
+        enabled: Boolean,
+        onClickLabel: String?,
+        role: Role?,
+        onClick: () -> Unit
+    ): Modifier = tagCloudItemPointerInputClickable(enabled) { onClick() }
+        .clickable(enabled, onClickLabel, role) {}
+
+    private fun Modifier.tagCloudItemPointerInputClickable(
+        enabled: Boolean,
+        onClick: () -> Unit
+    ) = composed {
+        val touchSlop = LocalViewConfiguration.current.touchSlop
+        var currentPointerPosition = remember { Offset.Unspecified }
+        var pointerMoveDistance = remember { 0f }
+        val modifier = pointerInput(Unit) {
+            awaitPointerEventScope {
+                while (true) {
+                    val event = awaitPointerEvent()
+                    val pointer = event.changes.last()
+                    when (event.type) {
+                        PointerEventType.Press -> {
+                            currentPointerPosition = pointer.position
+                            pointerMoveDistance = 0f
+                        }
+
+                        PointerEventType.Move -> {
+                            val newPos = pointer.position
+                            val diff = currentPointerPosition - newPos
+                            pointerMoveDistance += diff.getDistance()
+                            currentPointerPosition = newPos
+                        }
+
+                        PointerEventType.Release -> {
+                            if (pointerMoveDistance < touchSlop && enabled) {
+                                onClick()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        modifier
+    }
+
 }
 
 private fun Float.rescale(newMin: Float, newMax: Float): Float =


### PR DESCRIPTION
Resolves #1 
The idea is to manually handle the press and release, and if the move distance is less than the touch slope, call the click callback. At the same time keep the visual interaction from the `clickable` modifier.